### PR TITLE
Заставице командне лије за улазно/излазне фајлове

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work
 
 # Goreleaser Dist directory
 dist/
+
+#VSCode debug directory
+.vscode/

--- a/translit.go
+++ b/translit.go
@@ -36,10 +36,12 @@ var (
 	out  = bufio.NewWriter(os.Stdout)
 	out1 = os.Stdout
 
-	l2cPtr  = flag.Bool("l2c", false, "`Смер` пресловљавања је латиница у ћирилицу")
-	c2lPtr  = flag.Bool("c2l", false, "`Смер` пресловљавања је ћирилица у латиницу")
-	htmlPtr = flag.Bool("html", false, "`Формат` улаза је (X)HTML")
-	textPtr = flag.Bool("text", false, "`Формат` улаза је прости текст")
+	l2cPtr        = flag.Bool("l2c", false, "`Смер` пресловљавања је латиница у ћирилицу")
+	c2lPtr        = flag.Bool("c2l", false, "`Смер` пресловљавања је ћирилица у латиницу")
+	htmlPtr       = flag.Bool("html", false, "`Формат` улаза је (X)HTML")
+	textPtr       = flag.Bool("text", false, "`Формат` улаза је прости текст")
+	inputFilePtr  = flag.String("i", "", "Путања улазног фајла")
+	outputFilePtr = flag.String("o", "", "Путања улазног фајла")
 
 	tbl = trie.BuildFromMap(map[string]string{
 		"A":   "А",
@@ -1054,17 +1056,53 @@ func exitWithError(err error) {
 	os.Exit(1)
 }
 
-func main() {
+func openInputFile() {
+
+	inputFile, err := os.Open(*inputFilePtr)
+	if err != nil {
+		panic(err)
+	}
+
+	rdr = bufio.NewReader(inputFile)
+
+}
+
+func openOutputFile() {
+
+	outputFile, err := os.Create(*outputFilePtr)
+	if err != nil {
+		panic(err)
+	}
+
+	out = bufio.NewWriter(outputFile)
+
+}
+
+func processFlags() {
 	flag.Usage = Pomoc
 	flag.Parse()
-	if flag.NFlag() != 2 || *l2cPtr == *c2lPtr || *htmlPtr == *textPtr {
+	if *l2cPtr == *c2lPtr || *htmlPtr == *textPtr {
 		Pomoc()
 		os.Exit(0)
 	}
+
+	if *inputFilePtr != "" {
+		openInputFile()
+	}
+
+	if *outputFilePtr != "" {
+		openOutputFile()
+	}
+}
+
+func main() {
+
+	processFlags()
 
 	if *htmlPtr {
 		transliterateHtml()
 	} else if *textPtr {
 		transliterateText()
 	}
+
 }

--- a/translit.go
+++ b/translit.go
@@ -32,16 +32,15 @@ var (
 	doit    = true
 	version = "v0.2.1"
 
-	rdr  = bufio.NewReader(os.Stdin)
-	out  = bufio.NewWriter(os.Stdout)
-	out1 = os.Stdout
+	rdr = bufio.NewReader(os.Stdin)
+	out = bufio.NewWriter(os.Stdout)
 
 	l2cPtr        = flag.Bool("l2c", false, "`Смер` пресловљавања је латиница у ћирилицу")
 	c2lPtr        = flag.Bool("c2l", false, "`Смер` пресловљавања је ћирилица у латиницу")
 	htmlPtr       = flag.Bool("html", false, "`Формат` улаза је (X)HTML")
 	textPtr       = flag.Bool("text", false, "`Формат` улаза је прости текст")
 	inputFilePtr  = flag.String("i", "", "Путања улазног фајла")
-	outputFilePtr = flag.String("o", "", "Путања улазног фајла")
+	outputFilePtr = flag.String("o", "", "Путања излазног фајла")
 
 	tbl = trie.BuildFromMap(map[string]string{
 		"A":   "А",
@@ -1038,9 +1037,10 @@ func transliterateText() {
 			}
 			outl := strings.Join(words, " ")
 			outl += "\n"
-			if _, err = out1.WriteString(outl); err != nil {
+			if _, err = out.WriteString(outl); err != nil {
 				exitWithError(err)
 			}
+			_ = out.Flush()
 
 		case io.EOF:
 			os.Exit(0)


### PR DESCRIPTION
Шаљем предлог за увођење заставица за улазни и излазни фајл. У послатом решењу обе ове заставицу су опционе. Тиме се омогућава да се нпр дефинише заставица за улазни фајл, а да се стандарднои излаз редиректује у фајл. Или обрнуто, да се дефинише заставица за излазни фајл, а да се на стандардни улаз редиректује неки други наведени фајл.

Потребно је додатно тестирати могуће варијанте заставица (са већ постојећим) и евентуално дорадити код како би се програм очекивано понашао у случају недозвољене употребе заставица. 