### PR TITLE
Обрада фајлова чији типови нису подржани

### DIFF
--- a/internal/dictionary/dictionary.go
+++ b/internal/dictionary/dictionary.go
@@ -36,9 +36,6 @@ var (
 	ConfigPtr    = flag.Bool("c", false, "Користи се конфигурација")
 	InputPathPtr = flag.String("i", "", "Путања улазног фајла или директоријума")
 
-	TextMime = "text/plain; charset=utf-8"
-	HtmlMime = "text/html; charset=utf-8"
-
 	Tbl = trie.BuildFromMap(map[string]string{
 		"A":   "А",
 		"B":   "Б",


### PR DESCRIPTION
Овим захтевом се обезбеђује исправан рад програма када му се проследи фајл који није хтмл или текст. У том случају се исписује грешка за тај фајл. 
Ако се као улазни параметар проследи директоријум, пресловиће се сви фајлови чији типови су подржани, а остали неће.
У току будућег развоја потребно је обезбедити лепши испис у случају када се наиђе на овакав фајл (не исписивати за њега улазни и излазни фајл).

Такође, због проблема код препознавања MIME типа фајла, стринг се преводи у сва мала слова. Чиме не зависимо од тога да ли нам се врата мала или велика слова.