### PR TITLE
Унапређење тестова

### DIFF
--- a/cmd/translit/translit_test.go
+++ b/cmd/translit/translit_test.go
@@ -147,6 +147,46 @@ func TestL2CTextInputFile(t *testing.T) {
 	}
 }
 
+func TestL2CXmlInputFile(t *testing.T) {
+	*dictionary.L2cPtr = true
+	*dictionary.C2lPtr = false
+	*dictionary.InputPathPtr = "../../test/testdata/xmltest.xml"
+	flag.Parse()
+
+	expectedOutput, _ := filepath.Abs("../../test/testdata/xmltest_izlaz.xml")
+
+	main()
+
+	exist := isOutputFileExist()
+	clearData()
+
+	if !exist {
+		t.Fatalf(`Транслит није направио фајл %q`, getOutputFileName())
+	} else {
+		fmt.Fprintln(os.Stderr, "Пронађен!")
+	}
+
+	transliterated, err := os.Open(getOutputFileName())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer transliterated.Close()
+	expected, err := os.Open(expectedOutput)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer expected.Close()
+
+	checksumTransliterate := checksumSHA256(transliterated)
+	checksumExpected := checksumSHA256(expected)
+
+	if strings.Compare(checksumTransliterate, checksumExpected) != 0 {
+		t.Fatalf("Садржај пресловљеног фајла се разликује од очекиваног!")
+	} else {
+		fmt.Fprintln(os.Stderr, "Садржај пресловљеног фајла је исправан")
+	}
+}
+
 func clearData() {
 	terminal.InputFilenames = nil
 	terminal.InputFilePaths = nil

--- a/test/testdata/xmltest.xml
+++ b/test/testdata/xmltest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<poruka>
+	<naslov>Evo naslova tajne poruke</naslov>
+	<telo>
+		Da li je u redu da se <bitno>tajne stvari</bitno> šifruju?
+		Pošalji mi svoj javni ključ. Evo mog ključa:
+		<![CDATA[
+			-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+			mQINBFYaCXIBEAC3gDgm+9MKZV4va5dhIyUQOhRePHn+KQhxIAmyroDA04EBOwkE
+			EeluM420yStLeh0chdQyYsEOzEqzzUSgs7L7fI6jDo0qwcbtKOgZ+Lf7JaVH+g6j
+			wZqkLNzKFRFZPpKTmVUv9Z6U1TU2MfqgifiGmncVT7zChz1gb78W4SkIys38BvSm
+			g62rIFvyDvKZeUCFEuHS5JkZUbuK19JQRTeDrrenLNh4n8odsfVH8qGu20lS/aKr
+			G/Rg0lKwvfHzuJM1JqWAMpnbHQ==
+			=5hsn
+			-----END PGP PUBLIC KEY BLOCK-----
+			]]>
+		<datum>18.12.2825</datum>
+	</telo>
+</poruka>

--- a/test/testdata/xmltest_izlaz.xml
+++ b/test/testdata/xmltest_izlaz.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<poruka>
+	<naslov>Ево наслова тајне поруке</naslov>
+	<telo>
+		Да ли је у реду да се <bitno>тајне ствари</bitno> шифрују? Пошаљи ми свој јавни кључ. Ево мог кључа:
+		<![CDATA[
+			-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+			mQINBFYaCXIBEAC3gDgm+9MKZV4va5dhIyUQOhRePHn+KQhxIAmyroDA04EBOwkE
+			EeluM420yStLeh0chdQyYsEOzEqzzUSgs7L7fI6jDo0qwcbtKOgZ+Lf7JaVH+g6j
+			wZqkLNzKFRFZPpKTmVUv9Z6U1TU2MfqgifiGmncVT7zChz1gb78W4SkIys38BvSm
+			g62rIFvyDvKZeUCFEuHS5JkZUbuK19JQRTeDrrenLNh4n8odsfVH8qGu20lS/aKr
+			G/Rg0lKwvfHzuJM1JqWAMpnbHQ==
+			=5hsn
+			-----END PGP PUBLIC KEY BLOCK-----
+			]]>
+		<datum>18.12.2825</datum>
+	</telo>
+</poruka>


### PR DESCRIPTION
Овим се додаје тест који проверава пресловљавање XML фајлова са латинице у ћирилицу.

Затвара (#42)